### PR TITLE
The function 'unquote' is moved away from the public access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 0.5.1
+
+- The function 'unquote' is moved away from the public access in order to avoid possible clashes with the similar ones in consuming applications.
+
 ## 0.5.0
 
 - New feature: support for -name=value, -name="value", -name='value', -name="value1,value2,...", -name='value1,value2,...'.
-  In this case, the following arguments are not treated as values of this option
+  The next plain argument is not treated as another value of this option in order to avoid the visual confusion.
 
 ## 0.4.2
 

--- a/lib/src/parse_args_base.dart
+++ b/lib/src/parse_args_base.dart
@@ -2,6 +2,7 @@
 // All rights reserved under MIT license (see LICENSE file)
 
 import 'package:parse_args/src/opt_def.dart';
+import 'package:parse_args/src/str_ext.dart';
 
 /// A type for the user-defined handler which gets called on every option
 /// with the list of values (non-optional arguments between this option
@@ -54,7 +55,7 @@ void parseArgs(String? optDefStr, List<String> args, ParseArgsHandler handler,
       final breakPos = name.indexOf('=');
 
       if (breakPos >= 0) {
-        value = unquote(name.substring(breakPos + 1));
+        value = name.substring(breakPos + 1).unquote();
         name = name.substring(0, breakPos);
       }
     }
@@ -141,25 +142,4 @@ void parseArgs(String? optDefStr, List<String> args, ParseArgsHandler handler,
   }
 
   // Finish
-}
-
-/// A function to return a string with surrounding quotes removed from [input]
-///
-String unquote(String input) {
-  final length = input.length;
-
-  if (length <= 1) {
-    return input;
-  }
-
-  final lastPos = (length - 1);
-  final quote = input[0];
-
-  if ((quote == '"') || (quote == "'")) {
-    if (input[lastPos] == quote) {
-      return input.substring(1, lastPos);
-    }
-  }
-
-  return input;
 }

--- a/lib/src/str_ext.dart
+++ b/lib/src/str_ext.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2022, Alexander Iurovetski
+// All rights reserved under MIT license (see LICENSE file)
+
+/// Extension methods for the string manipulations
+///
+extension StrExt on String {
+  /// A function to return a string with surrounding quotes removed from [input]
+  ///
+  String unquote() {
+    final lastPos = (length - 1);
+
+    if (lastPos < 1) {
+      return this;
+    }
+
+    final quote = this[0];
+
+    if ((quote == '"') || (quote == "'")) {
+      if (this[lastPos] == quote) {
+        return substring(1, lastPos);
+      }
+    }
+
+    return this;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parse_args
 description: A Dart package to parse command-line options simple way and in a portable style (bash, find, java, PowerShell)
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/aiurovet/parse_args
 
 environment:

--- a/test/parse_args_test.dart
+++ b/test/parse_args_test.dart
@@ -134,23 +134,6 @@ void main() {
           throwsA((e) => e is OptValueUnexpectedException));
     });
   });
-  group('unquote -', () {
-    test('empty', () {
-      expect(unquote(''), '');
-    });
-    test('empty single-quoted', () {
-      expect(unquote("''"), '');
-    });
-    test('empty double-quoted', () {
-      expect(unquote('""'), '');
-    });
-    test('non-empty single-quoted', () {
-      expect(unquote(r"'ab\ncd'"), r'ab\ncd');
-    });
-    test('non-empty double-quoted', () {
-      expect(unquote(r'"ab\ncd"'), r'ab\ncd');
-    });
-  });
 }
 
 /// Parsed options handler: just prints whatever is passed

--- a/test/str_ext_test.dart
+++ b/test/str_ext_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2022, Alexander Iurovetski
+// All rights reserved under MIT license (see LICENSE file)
+
+import 'package:parse_args/src/str_ext.dart';
+import 'package:test/test.dart';
+
+/// A list of options to write result to
+///
+Map<String, List> opts = {};
+
+/// The main entry point for tests
+///
+void main() {
+  group('unquote -', () {
+    test('empty', () {
+      expect(''.unquote(), '');
+    });
+    test('empty single-quoted', () {
+      expect("''".unquote(), '');
+    });
+    test('empty double-quoted', () {
+      expect('""'.unquote(), '');
+    });
+    test('non-empty single-quoted', () {
+      expect(r"'ab\ncd'".unquote(), r'ab\ncd');
+    });
+    test('non-empty double-quoted', () {
+      expect(r'"ab\ncd"'.unquote(), r'ab\ncd');
+    });
+  });
+}


### PR DESCRIPTION
The function 'unquote' is moved away from the public access in order to avoid possible clashes with the similar ones in consuming applications.